### PR TITLE
反映 - UIテストを単体テストで代替。更にタイトルの位置ずれを同じライン上になるように横幅を合わせる

### DIFF
--- a/src/base/Element/CheckBox/checbox.test.tsx
+++ b/src/base/Element/CheckBox/checbox.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import useEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { describe, vi, test } from 'vitest';
+import { CheckBox } from './index';
+
+describe('ChekcBox Component', () => {
+  test('チェックボックスがクリックされた時にPropsの関数が呼び出されていること', async () => {
+    const onChange = vi.fn();
+    render(<CheckBox label={'TESTCity'} value={1} changeHandler={onChange} />);
+
+    const use = useEvent.setup();
+    const checkboxMock = screen.getByLabelText('TESTCity');
+    await use.click(checkboxMock);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('初期状態のチェックボックスはチェック状態ではないこと', () => {
+    const onChange = vi.fn();
+    render(<CheckBox label={'TESTCity'} value={1} changeHandler={onChange} />);
+
+    const checkboxMock = screen.getByLabelText('TESTCity');
+    expect(checkboxMock).not.toBeChecked();
+  });
+
+  test('チェックボックスがクリックされたら、チェック状態になっていること', async () => {
+    const onChange = vi.fn();
+    render(<CheckBox label={'TESTCity'} value={1} changeHandler={onChange} />);
+
+    const use = useEvent.setup();
+    const checkboxMock = screen.getByLabelText('TESTCity');
+    await use.click(checkboxMock);
+    expect(checkboxMock).toBeChecked();
+  });
+});

--- a/src/base/Element/Radio/radio.test.tsx
+++ b/src/base/Element/Radio/radio.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import useEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { describe, vi, test } from 'vitest';
+import { Radio } from './index';
+
+describe('ChekcBox Component', () => {
+  test('ラジオボタンがクリックされた時にPropsの関数が呼び出されていること', async () => {
+    const onChange = vi.fn();
+    render(
+      <Radio
+        label={'CategoryTypeA'}
+        value="Category"
+        checked={false}
+        categories="Mock"
+        changeHandler={onChange}
+      />
+    );
+
+    const use = useEvent.setup();
+    const radioMock = screen.getByLabelText('CategoryTypeA');
+    await use.click(radioMock);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('初期状態のラジオボタンはチェック状態ではないこと', () => {
+    const onChange = vi.fn();
+    render(
+      <Radio
+        label={'CategoryTypeA'}
+        value="Category"
+        checked={false}
+        categories="Mock"
+        changeHandler={onChange}
+      />
+    );
+
+    const checkboxMock = screen.getByLabelText('CategoryTypeA');
+    expect(checkboxMock).not.toBeChecked();
+  });
+});

--- a/src/feature/PopulationChart/components/Prefectures/index.tsx
+++ b/src/feature/PopulationChart/components/Prefectures/index.tsx
@@ -9,7 +9,9 @@ export const PrefectureList = () => {
   return (
     <article className={stlye.prefectures}>
       <h2>都道府県</h2>
-      <CheckBoxList values={prefectures} changeHandler={selectPrefectures} />
+      <div className={stlye.prefectures_list}>
+        <CheckBoxList values={prefectures} changeHandler={selectPrefectures} />
+      </div>
     </article>
   );
 };

--- a/src/feature/PopulationChart/styles/components/prefectures.module.scss
+++ b/src/feature/PopulationChart/styles/components/prefectures.module.scss
@@ -1,10 +1,16 @@
 .prefectures {
-  padding-left: 40px;
-  padding-right: 10px;
-
   @include mq(lg) {
-    padding-left: 60px;
-    padding-right: 0px;
     width: $medium-width;
+  }
+
+  .prefectures_list {
+    padding-left: 40px;
+    padding-right: 10px;
+
+    @include mq(lg) {
+      padding-left: 60px;
+      padding-right: 0px;
+      width: $medium-width;
+    }
   }
 }


### PR DESCRIPTION
StoryBookとVitestの組み合わせがまだ未対応な部分があるため、想定時のテストが実装できるか不明
そのため、代わりに通常のVitestのユニットテストでテストを代替する

都道府県と人口のタイトルが微妙にずれていたので、ラインを合わせて見た目の違和感をへらす